### PR TITLE
Fix saxpy test for gfx1151

### DIFF
--- a/examples/launch_saxpy.c
+++ b/examples/launch_saxpy.c
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    /* kernarg layout: {float *y, float *x, float a, int n} = 24 bytes */
+    /* kernarg layout follows AMDHSA alignment; keep n at byte offset 24. */
     bc_kernel_t kern;
     rc = bc_load_kernel(&dev, hsaco, "saxpy", &kern);
     if (rc != BC_RT_OK) {
@@ -72,13 +72,17 @@ int main(int argc, char *argv[])
         void    *y;
         void    *x;
         float    a;
+        uint32_t _pad0;
         uint32_t n;
+        uint32_t _pad1;
     } args;
 
     args.y = d_y;
     args.x = d_x;
     args.a = A_VAL;
+    args._pad0 = 0;
     args.n = N;
+    args._pad1 = 0;
 
     uint32_t num_blocks = (N + BLOCK - 1) / BLOCK;
     printf("  dispatch: %u blocks x %d threads\n", num_blocks, BLOCK);

--- a/examples/launch_saxpy.c
+++ b/examples/launch_saxpy.c
@@ -75,6 +75,12 @@ int main(int argc, char *argv[])
         uint32_t _pad0;
         uint32_t n;
         uint32_t _pad1;
+        uint32_t hidden_block_count_x;
+        uint32_t hidden_block_count_y;
+        uint32_t hidden_block_count_z;
+        uint16_t hidden_group_size_x;
+        uint16_t hidden_group_size_y;
+        uint16_t hidden_group_size_z;
     } args;
 
     args.y = d_y;
@@ -83,8 +89,14 @@ int main(int argc, char *argv[])
     args._pad0 = 0;
     args.n = N;
     args._pad1 = 0;
-
     uint32_t num_blocks = (N + BLOCK - 1) / BLOCK;
+    args.hidden_block_count_x = num_blocks;
+    args.hidden_block_count_y = 1;
+    args.hidden_block_count_z = 1;
+    args.hidden_group_size_x = BLOCK;
+    args.hidden_group_size_y = 1;
+    args.hidden_group_size_z = 1;
+
     printf("  dispatch: %u blocks x %d threads\n", num_blocks, BLOCK);
 
     rc = bc_dispatch(&dev, &kern, num_blocks, 1, 1, BLOCK, 1, 1,

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,89 @@
+{
+  description = "BarraCUDA flake (devShell sets LD_LIBRARY_PATH for libhsa-runtime64.so)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        lib = pkgs.lib;
+
+        rocmPkgs =
+          if pkgs ? rocmPackages then pkgs.rocmPackages
+          else throw "This nixpkgs does not provide pkgs.rocmPackages; use a newer nixpkgs.";
+
+        # Pick a package that provides libhsa-runtime64.so (ROCR / HSA runtime).
+        hsaRuntime =
+          let
+            candidates = [
+              "hsa-rocr"
+              "hsa-rocr-runtime"
+              "rocm-runtime"
+              "rocm-runtime-unwrapped"
+            ];
+            name = lib.findFirst (n: builtins.hasAttr n rocmPkgs) null candidates;
+          in
+            if name == null then
+              throw "Could not find an ROCm HSA runtime in pkgs.rocmPackages (tried: ${builtins.toString candidates})."
+            else
+              rocmPkgs.${name};
+
+        barracuda = pkgs.stdenv.mkDerivation {
+          pname = "barracuda";
+          version = "unstable";
+          src = ./.;
+
+          nativeBuildInputs = [ pkgs.gnumake pkgs.makeWrapper ];
+
+          buildPhase = "make";
+
+          installPhase = ''
+            runHook preInstall
+            install -Dm755 barracuda $out/bin/barracuda
+            runHook postInstall
+          '';
+
+          # Convenience for `nix run .` so barracuda can dlopen() libhsa-runtime64.so.
+          postFixup = ''
+            wrapProgram $out/bin/barracuda \
+              --prefix LD_LIBRARY_PATH : ${hsaRuntime}/lib:${hsaRuntime}/lib64
+          '';
+
+          meta = {
+            homepage = "https://github.com/Zaneham/BarraCUDA";
+            license = lib.licenses.asl20;
+            mainProgram = "barracuda";
+            platforms = lib.platforms.linux;
+          };
+        };
+      in
+      {
+        packages = {
+          default = barracuda;
+          barracuda = barracuda;
+          hsaRuntime = hsaRuntime;
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${barracuda}/bin/barracuda";
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = [
+            pkgs.gcc
+            pkgs.gnumake
+            hsaRuntime
+          ];
+
+          shellHook = ''
+            # bc_runtime.c dlopen("libhsa-runtime64.so") relies on the loader search path.
+            export LD_LIBRARY_PATH=${hsaRuntime}/lib:${hsaRuntime}/lib64''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+          '';
+        };
+      });
+}

--- a/src/amdgpu/amdgpu.h
+++ b/src/amdgpu/amdgpu.h
@@ -372,8 +372,8 @@ typedef struct {
     uint32_t compute_pgm_rsrc3;
     uint32_t compute_pgm_rsrc1;
     uint32_t compute_pgm_rsrc2;
-    uint16_t kernel_code_properties;
-    uint8_t  reserved2[6];
+    uint32_t kernel_code_properties;
+    uint8_t  reserved2[4];
 } amd_kernel_descriptor_t;  /* 64 bytes */
 
 /* ---- Module ---- */

--- a/src/amdgpu/emit.c
+++ b/src/amdgpu/emit.c
@@ -926,17 +926,21 @@ int amdgpu_emit_elf(amd_module_t *A, const char *path)
                                     (1u << 27);    /* MEM_ORDERED (RDNA only) */
         }
 
-        /* compute_pgm_rsrc2 — [0] SCRATCH_EN, [5:1] USER_SGPR_COUNT,
-           [7] TGID_X, [8] TGID_Y, [9] TGID_Z, [12:11] VGPR_WORKITEM_ID.
-           Layout matches what isel's scan_kernel_needs() decided. */
+        /* compute_pgm_rsrc2.
+         * CDNA/GFX9 uses TGID bits at 11/12/13. RDNA keeps 7/8/9 and
+         * VGPR_WORKITEM_ID at 12:11. */
         {
-            uint32_t user_sgpr = 2u; /* s[0:1] = kernarg only */
+            uint32_t tgid_x = cdna ? 11u : 7u;
+            uint32_t tgid_y = cdna ? 12u : 8u;
+            uint32_t tgid_z = cdna ? 13u : 9u;
+            uint32_t user_sgpr = 4u; /* dispatch_ptr + kernarg_ptr */
             uint32_t rsrc2 = ((F->scratch_bytes > 0) ? 1u : 0u) |
                              (user_sgpr << 1) |
-                             (1u << 7);       /* TGID_X always enabled */
-            if (F->max_dim >= 1) rsrc2 |= (1u << 8);  /* TGID_Y */
-            if (F->max_dim >= 2) rsrc2 |= (1u << 9);  /* TGID_Z */
-            rsrc2 |= ((uint32_t)F->max_dim << 11);    /* VGPR_WORKITEM_ID */
+                             (1u << tgid_x);
+            if (F->max_dim >= 1) rsrc2 |= (1u << tgid_y);
+            if (F->max_dim >= 2) rsrc2 |= (1u << tgid_z);
+            if (!cdna)
+                rsrc2 |= ((uint32_t)F->max_dim << 11);
             kd.compute_pgm_rsrc2 = rsrc2;
         }
 
@@ -950,9 +954,12 @@ int amdgpu_emit_elf(amd_module_t *A, const char *path)
             kd.compute_pgm_rsrc3 = accum_off & 0x3F;
         }
 
-        /* kernel_code_properties — only KERNARG_PTR.
-         * No dispatch_ptr; blockDim/gridDim come from hidden kernarg. */
-        kd.kernel_code_properties = (1u << 3);   /* ENABLE_SGPR_KERNARG_PTR */
+        /* kernel_code_properties (amd_hsa_kernel_code.h) */
+        kd.kernel_code_properties = (1u << 1) |  /* ENABLE_SGPR_DISPATCH_PTR */
+                                    (1u << 3) |  /* ENABLE_SGPR_KERNARG_PTR */
+                                    (1u << 19);  /* IS_PTR64 */
+        if (!cdna)
+            kd.kernel_code_properties |= (1u << 10); /* WAVEFRONT_SIZE32 */
 
         if (rodata_len + 64 <= sizeof(rodata)) {
             memcpy(rodata + rodata_len, &kd, 64);

--- a/src/amdgpu/emit.c
+++ b/src/amdgpu/emit.c
@@ -795,6 +795,17 @@ typedef struct {
 } elf64_shdr_t;   /* 64 bytes */
 
 typedef struct {
+    uint32_t p_type;
+    uint32_t p_flags;
+    uint64_t p_offset;
+    uint64_t p_vaddr;
+    uint64_t p_paddr;
+    uint64_t p_filesz;
+    uint64_t p_memsz;
+    uint64_t p_align;
+} elf64_phdr_t;   /* 56 bytes */
+
+typedef struct {
     uint32_t st_name;
     uint8_t  st_info;
     uint8_t  st_other;
@@ -1344,10 +1355,11 @@ int amdgpu_emit_elf(amd_module_t *A, const char *path)
     ehdr.e_ident[5] = 1;    /* ELFDATA2LSB */
     ehdr.e_ident[6] = 1;    /* EV_CURRENT */
     ehdr.e_ident[7] = ELFOSABI_AMDGPU_HSA;
-    ehdr.e_ident[8] = 4;    /* ABI version 4 — code object v6 */
+    ehdr.e_ident[8] = 1;    /* ELFABIVERSION_AMDGPU_HSA_V3 */
     ehdr.e_type = 3;         /* ET_DYN */
     ehdr.e_machine = EM_AMDGPU;
     ehdr.e_version = 1;
+    ehdr.e_entry = 0;
     ehdr.e_phoff = phdr_off;
     ehdr.e_shoff = shdr_off;
     ehdr.e_flags = A->elf_mach;

--- a/src/amdgpu/emit.c
+++ b/src/amdgpu/emit.c
@@ -821,17 +821,6 @@ typedef struct {
 } elf64_nhdr_t;   /* 12 bytes */
 
 typedef struct {
-    uint32_t p_type;
-    uint32_t p_flags;
-    uint64_t p_offset;
-    uint64_t p_vaddr;
-    uint64_t p_paddr;
-    uint64_t p_filesz;
-    uint64_t p_memsz;
-    uint64_t p_align;
-} elf64_phdr_t;   /* 56 bytes */
-
-typedef struct {
     int64_t  d_tag;
     uint64_t d_val;
 } elf64_dyn_t;    /* 16 bytes */

--- a/src/amdgpu/isel.c
+++ b/src/amdgpu/isel.c
@@ -1839,13 +1839,20 @@ static void scan_kernel_needs(const bir_func_t *F)
     }
     if (S.max_dim > 2) S.max_dim = 2; /* clamp */
 
-    /* SGPR layout — always: s[0:1]=kernarg, s2+=TGID.
-     * No dispatch_ptr; blockDim/gridDim read from hidden kernarg
-     * (same approach as hipcc — dispatch_ptr + multi-arg is cursed). */
-    S.sgpr_dispatch = 0xFFFF;
-    S.sgpr_kernarg  = 0;     /* s[0:1] = kernarg ptr */
-    S.sgpr_wg_base  = 2;     /* s2+ = workgroup IDs */
-    S.kern_reserved = 2 + 1 + S.max_dim; /* after last TGID */
+    /* SGPR layout depends on dispatch usage.
+     * With dispatch_ptr: s[0:1]=dispatch, s[2:3]=kernarg, s4+=TGID.
+     * Without dispatch_ptr: s[0:1]=kernarg, s2+=TGID. */
+    if (S.needs_dispatch) {
+        S.sgpr_dispatch = 0;
+        S.sgpr_kernarg = 2;
+        S.sgpr_wg_base = 4;
+        S.kern_reserved = 4 + 1 + S.max_dim;
+    } else {
+        S.sgpr_dispatch = 0xFFFF;
+        S.sgpr_kernarg = 0;
+        S.sgpr_wg_base = 2;
+        S.kern_reserved = 2 + 1 + S.max_dim;
+    }
     /* Align reserved to even for SGPR pair loads */
     if (S.kern_reserved & 1) S.kern_reserved++;
 }


### PR DESCRIPTION
This patch was written by codex, so I'm not necessarily expecting a merge. But hopefully it helps!
Here's a summary (written by me) of the issues and fixes.

(XREF: Issue #39)

## Problem 1: hsaco loading fails

First problem: unable to load the hsaco file:

```
BarraCUDA SAXPY launcher
  .hsaco:  test.hsaco
  N:       1024
  a:       2.5
bc_runtime: GPU ready, queue size 131072
bc_runtime: executable_load failed (0x1010)
Kernel load failed (-3)
```

Fix is in `eb04b1b7ecebe5e53794090bf3ad9e92d8eb1ab3`, adds a couple of ELF segments and changes ELF header to include:

```
    ehdr.e_ident[8] = 1;    /* ELFABIVERSION_AMDGPU_HSA_V3 */
    ehdr.e_type = 3;        /* ET_DYN (AMDGPU code object) */
```

**Warning**: it looks like the e_ident change might break other platforms. I'm not sure if this can be merged as-is.

## Problem 2: memory aperture violation

With previous fix applied, we unlock a new error:

```
BarraCUDA SAXPY launcher
  .hsaco:  test.hsaco
  N:       1024
  a:       2.5
bc_runtime: GPU ready, queue size 131072
bc_runtime: loaded 'saxpy' (kernarg=32, lds=0, scratch=0)
  dispatch: 4 blocks x 256 threads
Queue at 0x7ffff7b96000 inactivated due to async error:
        HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION: The agent attempted to access memory beyond the largest legal address.
./run.sh: line 15: 678661 Aborted                    (core dumped) nix develop .#default --command ./launch_saxpy test.hsaco
```

The fix for this is in `2119a9bc9d2981b12a1b2e76ac4af8783a7f06b0`.
tl;dr: sets some additional properties in the `amd_kernel_descriptor_t`.

## Problem 3: test fails

Last problem, saxpy test fails with mismatches:

```
BarraCUDA SAXPY launcher
  .hsaco:  test.hsaco
  N:       1024
  a:       2.5
bc_runtime: GPU ready, queue size 131072
bc_runtime: loaded 'saxpy' (kernarg=32, lds=0, scratch=0)
  dispatch: 4 blocks x 256 threads
  MISMATCH [1]: got 1023.0000, expected 1025.5000
  MISMATCH [2]: got 1022.0000, expected 1027.0000
  MISMATCH [3]: got 1021.0000, expected 1028.5000
  MISMATCH [4]: got 1020.0000, expected 1030.0000
  MISMATCH [5]: got 1019.0000, expected 1031.5000
  FAIL: 1023/1024 mismatches
```

This is fixed by `32857b901393809ffa15fcbc136ba69a9b83b81d`.
tl;dr: adds some padding to the `args` struct in `launch_saxpy.c` to (apparently) obey AMDHSA ABI.

## Result

With all these patches applied, I now see a working result:

```
BarraCUDA SAXPY launcher
  .hsaco:  test.hsaco
  N:       1024
  a:       2.5
bc_runtime: GPU ready, queue size 131072
bc_runtime: loaded 'saxpy' (kernarg=32, lds=0, scratch=0)
  dispatch: 4 blocks x 256 threads
  PASS: all 1024 elements correct
```