### PR TITLE
0.5 release

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,8 +2,8 @@ BarraCUDA — Changelog
 =====================
 
 2026-05-29 — 0.5 release. The headline is that you can write a
-Triton kernel, matmul and all, and run it on a CPU with no GPU and
-no LLVM. The CPU backend (`--cpu`) lowers BIR straight to x86-64
+Triton kernel, matmul and all, and run it on a CPU with no GPU.
+The CPU backend (`--cpu`) lowers BIR straight to x86-64
 with the SIMT model collapsed into a thread loop, and the rank-2
 tile path materialises and unrolls so `tl.dot` plus a K-loop
 sweeps an arbitrary contraction. A RISC-V backend (`--rv64`) lands

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,7 @@
 BarraCUDA — Changelog
 =====================
 
-2026-05-28 — 0.5 release. The headline is that you can write a
+2026-05-29 — 0.5 release. The headline is that you can write a
 Triton kernel, matmul and all, and run it on a CPU with no GPU and
 no LLVM. The CPU backend (`--cpu`) lowers BIR straight to x86-64
 with the SIMT model collapsed into a thread loop, and the rank-2
@@ -14,7 +14,14 @@ oracle, every case runs `--inject` so a green result actually
 means something (see tests/diff). Triton picks up scalar math
 intrinsics (exp/log/sin/cos/tan/tanh/sqrt/rsqrt/abs/floor/ceil/
 maximum/minimum/fdiv) thanks to @shivam2931120, who got the
-radians-to-turns convention right first time. Adds `--version`.
+radians-to-turns convention right first time. Triton constexpr
+params with a default value now fold to literals at lower time
+and drop out of the runtime signature too, so the matmul example
+loses three unused args. Two small CUDA fixes for `--cpu` and
+`--rv64` on their own: sema actually runs (the lowerer needs
+it), and the parse-dump fallback no longer fires by accident, so
+typedef-struct kernels compile through `--cpu` and `--parse` no
+longer segfaults on the synthetic anon name. Adds `--version`.
 
 2026-05-26 — Triton matmul K-loop, so big matrices work. The
 Triton lowerer now lowers `for k in range(...)` as a real counted

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,21 @@
 BarraCUDA — Changelog
 =====================
 
+2026-05-28 — 0.5 release. The headline is that you can write a
+Triton kernel, matmul and all, and run it on a CPU with no GPU and
+no LLVM. The CPU backend (`--cpu`) lowers BIR straight to x86-64
+with the SIMT model collapsed into a thread loop, and the rank-2
+tile path materialises and unrolls so `tl.dot` plus a K-loop
+sweeps an arbitrary contraction. A RISC-V backend (`--rv64`) lands
+alongside, emitting RV64IMFD objects that run under qemu, which
+makes cross-backend differential testing a thing on a laptop: same
+BIR through two backends, diff the output buffers, CPU is the
+oracle, every case runs `--inject` so a green result actually
+means something (see tests/diff). Triton picks up scalar math
+intrinsics (exp/log/sin/cos/tan/tanh/sqrt/rsqrt/abs/floor/ceil/
+maximum/minimum/fdiv) thanks to @shivam2931120, who got the
+radians-to-turns convention right first time. Adds `--version`.
+
 2026-05-26 — Triton matmul K-loop, so big matrices work. The
 Triton lowerer now lowers `for k in range(...)` as a real counted
 loop, which lets a matmul sweep an arbitrary contraction dimension

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ make
 # the end, nthreads. The body runs once per thread_id up to nthreads, so a
 # 1-D launch just hands it the element count. See examples/cpu_launch_vadd.c.
 
+# RISC-V backend: same idea, RV64IMFD object you run under qemu-riscv64.
+./barracuda --rv64 kernel.cu -o kernel_rv.o
+# These are System V ELF objects, so link and run them on Linux (or WSL),
+# not under MinGW (wrong ABI). The rv64 host has to be freestanding, see
+# tests/diff for a worked runner.
+
+# Differential testing: run the same kernel on two backends and diff the
+# results. The CPU backend is the oracle, so a disagreement points at the
+# other backend's codegen. Genuine cross-backend (x86 vs RISC-V), no GPU.
+bash tests/diff/run_diff.sh
+
 # Dump the IR (for debugging or curiosity)
 ./barracuda --ir kernel.cu
 

--- a/examples/cpu_launch_matmul.c
+++ b/examples/cpu_launch_matmul.c
@@ -5,10 +5,9 @@
  * natively against a host reference. No GPU, no LLVM anywhere.
  *
  * The kernel is one 4x4 output tile (BLOCK_M = BLOCK_N = BLOCK_K = 4).
- * The constexpr values fold into the body during lowering (the tile is
- * materialised at compile time), but the params themselves stay in the
- * runtime signature, so they have to be passed even though the kernel
- * does not read them. The rank-2 tile path runs as a single logical
+ * The constexpr values fold into the body during lowering, and the
+ * lowerer drops them from the runtime signature too, so the host does
+ * not need to pass them. The rank-2 tile path runs as a single logical
  * thread, so nthreads = 1.
  *
  * Build (Linux / WSL):
@@ -18,13 +17,12 @@
  */
 #include <stdio.h>
 
-/* a, b, c, six strides, the three (unused at runtime) constexpr block
- * sizes, then the hidden nthreads. */
+/* a, b, c, six strides, then the hidden nthreads. The three constexpr
+ * block sizes were folded out of the signature at lower time. */
 extern void matmul(float *a, float *b, float *c,
                    int stride_am, int stride_ak,
                    int stride_bk, int stride_bn,
                    int stride_cm, int stride_cn,
-                   int block_m, int block_n, int block_k,
                    int nthreads);
 
 #define M 4
@@ -41,9 +39,9 @@ int main(void)
     for (int i = 0; i < K * N; i++) b[i] = (float)((i * 5) % 13) * 0.5f  - 2.0f;
     for (int i = 0; i < M * N; i++) c[i] = -123.0f;
 
-    /* Row-major strides for all three matrices. Block sizes echo the
-     * constexpr defaults; nthreads = 1 because the tile is materialised. */
-    matmul(a, b, c, K, 1, N, 1, N, 1, M, N, K, /* nthreads */ 1);
+    /* Row-major strides for all three matrices. nthreads = 1 because
+     * the tile is materialised at compile time. */
+    matmul(a, b, c, K, 1, N, 1, N, 1, /* nthreads */ 1);
 
     /* Host reference: plain triple loop. */
     for (int m = 0; m < M; m++) {

--- a/examples/cpu_launch_matmul.c
+++ b/examples/cpu_launch_matmul.c
@@ -1,0 +1,71 @@
+/* cpu_launch_matmul.c -- run a Triton matmul kernel on the CPU.
+ *
+ * The headline 0.5 demo: take the matmul kernel from tests/tri_matmul.py,
+ * compile it through BarraCUDA's --cpu backend, link it here, and run it
+ * natively against a host reference. No GPU, no LLVM anywhere.
+ *
+ * The kernel is one 4x4 output tile (BLOCK_M = BLOCK_N = BLOCK_K = 4).
+ * The constexpr values fold into the body during lowering (the tile is
+ * materialised at compile time), but the params themselves stay in the
+ * runtime signature, so they have to be passed even though the kernel
+ * does not read them. The rank-2 tile path runs as a single logical
+ * thread, so nthreads = 1.
+ *
+ * Build (Linux / WSL):
+ *   ./barracuda --triton --cpu -o matmul.o tests/tri_matmul.py
+ *   gcc -no-pie examples/cpu_launch_matmul.c matmul.o -o cpu_matmul
+ *   ./cpu_matmul
+ */
+#include <stdio.h>
+
+/* a, b, c, six strides, the three (unused at runtime) constexpr block
+ * sizes, then the hidden nthreads. */
+extern void matmul(float *a, float *b, float *c,
+                   int stride_am, int stride_ak,
+                   int stride_bk, int stride_bn,
+                   int stride_cm, int stride_cn,
+                   int block_m, int block_n, int block_k,
+                   int nthreads);
+
+#define M 4
+#define N 4
+#define K 4
+
+int main(void)
+{
+    float a[M * K], b[K * N], c[M * N], ref[M * N];
+
+    /* Some signs and fractions, so the float path is exercised properly
+     * and a wrong shift or stride would jump out. */
+    for (int i = 0; i < M * K; i++) a[i] = (float)((i * 7) % 11) * 0.25f - 1.0f;
+    for (int i = 0; i < K * N; i++) b[i] = (float)((i * 5) % 13) * 0.5f  - 2.0f;
+    for (int i = 0; i < M * N; i++) c[i] = -123.0f;
+
+    /* Row-major strides for all three matrices. Block sizes echo the
+     * constexpr defaults; nthreads = 1 because the tile is materialised. */
+    matmul(a, b, c, K, 1, N, 1, N, 1, M, N, K, /* nthreads */ 1);
+
+    /* Host reference: plain triple loop. */
+    for (int m = 0; m < M; m++) {
+        for (int n = 0; n < N; n++) {
+            float acc = 0.0f;
+            for (int k = 0; k < K; k++) acc += a[m * K + k] * b[k * N + n];
+            ref[m * N + n] = acc;
+        }
+    }
+
+    int ok = 1;
+    for (int i = 0; i < M * N; i++) {
+        if (c[i] != ref[i]) { ok = 0; break; }
+    }
+
+    printf("C =\n");
+    for (int m = 0; m < M; m++) {
+        printf(" ");
+        for (int n = 0; n < N; n++) printf(" %8.3f", c[m * N + n]);
+        printf("\n");
+    }
+    printf(ok ? "OK: Triton matmul ran on the CPU, matches host reference.\n"
+              : "MISMATCH: kernel output differs from host reference.\n");
+    return ok ? 0 : 1;
+}

--- a/src/barracuda.h
+++ b/src/barracuda.h
@@ -5,6 +5,12 @@
 #include <stdio.h>
 #include <string.h>
 
+/* ---- Version ---- */
+#define BC_VERSION_MAJOR    0
+#define BC_VERSION_MINOR    5
+#define BC_VERSION_PATCH    0
+#define BC_VERSION_STRING   "0.5.0"
+
 /* The universe has limits. So do our buffers. No malloc, no madness. */
 #define BC_MAX_SOURCE       (4 * 1024 * 1024)
 #define BC_MAX_TOKENS       (1 << 20)

--- a/src/fe/parser.c
+++ b/src/fe/parser.c
@@ -1563,7 +1563,14 @@ static void dump_node_data(const parser_t *P, const ast_node_t *n)
     {
         int len = (int)n->d.text.len;
         if (len > 120) len = 120;
-        memcpy(text, P->src + n->d.text.offset, (size_t)len);
+        /* Synthetic anon names live in P->anon_buf, not P->src. Offsets
+         * at or above BC_ANON_BASE are sentinels into the anon buffer;
+         * blindly reading P->src + huge_offset segfaults, which the
+         * typedef-struct dump tripped hard. */
+        const char *base = (n->d.text.offset >= BC_ANON_BASE)
+            ? P->anon_buf + (n->d.text.offset - BC_ANON_BASE)
+            : P->src + n->d.text.offset;
+        memcpy(text, base, (size_t)len);
         text[len] = '\0';
         printf(" %s", text);
         break;
@@ -1633,6 +1640,7 @@ void ast_dump(const parser_t *P, uint32_t idx, int depth)
         uint32_t ni = stack[top].node;
         int d = stack[top].depth;
         int phase = stack[top].phase;
+        if (ni >= P->num_nodes) return;
         const ast_node_t *n = &P->nodes[ni];
 
         if (phase == 0) {
@@ -1649,7 +1657,7 @@ void ast_dump(const parser_t *P, uint32_t idx, int depth)
                 int nc = 0;
                 uint32_t c = n->first_child;
                 uint32_t guard = P->max_nodes;
-                while (c && nc < BC_MAX_DEPTH && --guard) {
+                while (c && c < P->num_nodes && nc < BC_MAX_DEPTH && --guard) {
                     children[nc++] = c;
                     c = P->nodes[c].next_sibling;
                 }

--- a/src/main.c
+++ b/src/main.c
@@ -467,7 +467,7 @@ int main(int argc, char *argv[])
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--version") == 0) {
             printf("BarraCUDA %s\n", BC_VERSION_STRING);
-            printf("From-scratch CUDA/HIP/Triton compiler. Zero LLVM.\n");
+            printf("From-scratch CUDA/HIP/Triton compiler.\n");
             return 0;
         }
         else if (strcmp(argv[i], "--lex") == 0)

--- a/src/main.c
+++ b/src/main.c
@@ -406,8 +406,10 @@ static void usage(const char *prog)
         "  --nvidia-ptx  Compile to NVIDIA PTX (sm_89)\n"
         "  --hip         HIP frontend mode (predefines __HIPCC__ and platform macros;\n"
         "                auto-on for .hip files; combine with --amdgpu-bin or --nvidia-ptx)\n"
-        "  --triton      Triton frontend mode (parses Python source); use --lex to dump\n"
-        "                tokens or --parse to dump the AST; sema/lower still to come\n"
+        "  --triton      Triton frontend mode (parses Python source). Pair with a target\n"
+        "                backend (--cpu, --amdgpu-bin, --nvidia-ptx). tl.dot matmul runs.\n"
+        "  --cpu         x86-64 host backend; emits a normal object you can link and run\n"
+        "  --rv64        RV64IMFD backend; emits a Linux ELF object (run under qemu-riscv64)\n"
         "  --metal       Compile to Apple Metal Shading Language (stub)\n"
         "  --intel-spirv Compile to SPIR-V for Intel Arc Xe (stub)\n"
         "  --xe-lpg      Target Xe-LPG (Arc / integrated)\n"
@@ -416,6 +418,7 @@ static void usage(const char *prog)
         "  --xe2         Target Xe2 (Lunar Lake, next-gen Arc)\n"
         "  -o <file>     Output file (for --amdgpu-bin, --tensix, --nvidia-ptx, --metal, --intel-spirv)\n"
         "  --lang <file> Load translated error messages\n"
+        "  --version     Print version and exit\n"
         "  --help        Show this message\n"
         "\n", prog);
 }
@@ -462,7 +465,12 @@ int main(int argc, char *argv[])
     int num_defines = 0;
 
     for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "--lex") == 0)
+        if (strcmp(argv[i], "--version") == 0) {
+            printf("BarraCUDA %s\n", BC_VERSION_STRING);
+            printf("From-scratch CUDA/HIP/Triton compiler. Zero LLVM.\n");
+            return 0;
+        }
+        else if (strcmp(argv[i], "--lex") == 0)
             mode_lex = 1;
         else if (strcmp(argv[i], "--parse") == 0)
             mode_parse = 1;

--- a/src/main.c
+++ b/src/main.c
@@ -613,7 +613,7 @@ int main(int argc, char *argv[])
 
     if (!mode_pp && !mode_lex && !mode_parse && !mode_sema && !mode_ir &&
         !mode_amdgpu && !mode_amdgpu_bin && !mode_tensix && !mode_nvidia &&
-        !mode_metal && !mode_intel && !mode_rv_elf)
+        !mode_metal && !mode_intel && !mode_rv_elf && !mode_cpu && !mode_rv64)
         mode_parse = 1;
 
     /* ---- HIP NOTES (1 of 2) -------------------------------------------
@@ -914,7 +914,8 @@ int main(int argc, char *argv[])
         /* Semantic analysis */
         sema_ctx_t *sema_ctx = NULL;
         if ((mode_sema || mode_ir || mode_amdgpu || mode_amdgpu_bin ||
-             mode_tensix || mode_nvidia || mode_metal || mode_intel) &&
+             mode_tensix || mode_nvidia || mode_metal || mode_intel ||
+             mode_cpu || mode_rv64 || mode_rv_elf) &&
             P.num_errors == 0)
         {
             sema_ctx = (sema_ctx_t *)malloc(sizeof(sema_ctx_t));

--- a/src/triton/lower.c
+++ b/src/triton/lower.c
@@ -266,8 +266,15 @@ static uint32_t l_name(tn_lower_t *L, uint32_t node_idx)
     case TN_SYM_PARAM: {
         /* The parameter's BIR value was emitted when we lowered the
          * function header. Look it up by its position relative to
-         * cur_param_base. */
-        return BIR_MAKE_VAL(L->cur_param_base + aux);
+         * cur_param_base. Constexpr params with a default folded into
+         * a literal during the header (no BIR_PARAM was emitted), so
+         * we hand back the constant directly. */
+        if (aux < 32 && L->param_remap[aux] == 0xFF) {
+            return BIR_MAKE_CONST(bir_const_int(L->bir, L->t_i32,
+                                                L->param_const[aux]));
+        }
+        uint32_t bir_idx = (aux < 32) ? L->param_remap[aux] : (uint8_t)aux;
+        return BIR_MAKE_VAL(L->cur_param_base + bir_idx);
     }
     case TN_SYM_LOCAL:
     case TN_SYM_LOOPVAR: {
@@ -1305,13 +1312,20 @@ static void l_funcdef(tn_lower_t *L, uint32_t node_idx, int is_kernel)
         F->name = bir_add_string(M, P->lex->src + t->off, t->len);
     }
 
-    /* Collect parameters: each PARAM child becomes a BIR_PARAM.
-     * Build a function type with i32* pointee for each param so
-     * the backends have something to work with. */
+    /* Collect parameters: each PARAM child becomes a BIR_PARAM unless
+     * it is a constexpr-with-default, in which case it gets folded to a
+     * literal at lower time and dropped from the runtime signature.
+     * param_remap maps source-position to BIR-position; the source-
+     * position matches the kid index because params come before the
+     * body, so sema's TN_SYM_PARAM aux lands in the same slot. */
     uint32_t nk = l_nkids(n);
     uint32_t param_types[32];
     int num_params = 0;
-    for (uint32_t i = 0; i < nk && num_params < 32; i++) {
+    for (int j = 0; j < 32; j++) {
+        L->param_remap[j] = 0xFF;
+        L->param_const[j] = -1;
+    }
+    for (uint32_t i = 0; i < nk && i < 32 && num_params < 32; i++) {
         uint32_t kid = l_kid(L, node_idx, i);
         if (P->nodes[kid].kind == TN_NK_PARAM) {
             /* Sitting two default: a parameter whose name ends in
@@ -1348,13 +1362,24 @@ static void l_funcdef(tn_lower_t *L, uint32_t node_idx, int is_kernel)
                     break;
                 }
             }
-            if (is_constexpr) {
+            int has_default = (L->sema->node_const_val[kid] >= 0);
+            if (is_constexpr && has_default) {
+                /* Fold the value, drop the param from the BIR signature.
+                 * 0xFF in the remap tells l_name to return a literal. */
+                L->param_remap[i] = 0xFF;
+                L->param_const[i] = L->sema->node_const_val[kid];
+            } else if (is_constexpr) {
+                /* Constexpr without a default keeps a runtime slot, so
+                 * existing fixtures (vadd's BLOCK_SIZE) still work. */
+                L->param_remap[i] = (uint8_t)num_params;
                 param_types[num_params++] = L->t_i32;
             } else if (is_ptr) {
+                L->param_remap[i] = (uint8_t)num_params;
                 param_types[num_params++] = L->t_ptr_f32;
             } else {
                 /* Default: assume i32 scalar for things like
                  * n_elements that look like sizes. */
+                L->param_remap[i] = (uint8_t)num_params;
                 param_types[num_params++] = L->t_i32;
             }
         }

--- a/src/triton/triton.h
+++ b/src/triton/triton.h
@@ -513,6 +513,15 @@ typedef struct {
     uint32_t        cur_block;      /* BIR block index in flight */
     uint32_t        cur_param_base; /* index of first BIR_PARAM in current func */
 
+    /* Constexpr ABI compaction. A tl.constexpr param with a default
+     * value is folded into literals at lowering time and dropped from
+     * the runtime signature (so the host does not have to pass it). For
+     * each source-position param, param_remap[i] is its compacted BIR
+     * param index, or 0xFF if the param was dropped. param_const[i]
+     * carries the folded value when param_remap[i] == 0xFF. */
+    uint8_t         param_remap[32];
+    int32_t         param_const[32];
+
     /* Map from AST node index to BIR value reference, BIR_VAL_NONE
      * if not yet produced. Used to resolve Name references back to
      * the value their declaring node generated. */

--- a/tests/diff/README.md
+++ b/tests/diff/README.md
@@ -1,0 +1,59 @@
+# Differential testing
+
+One BIR, many targets. Run the same kernel through two backends and diff
+the output buffers. If they disagree, one backend's codegen is wrong, and
+since the CPU backend is the simplest target it makes a reliable oracle.
+This is the fastest way to answer the question that keeps coming up: when a
+kernel gives a wrong answer, is it the maths or the codegen?
+
+## Run it
+
+```bash
+bash tests/diff/run_diff.sh
+```
+
+It runs on Linux or WSL, not MinGW (see the ABI note below). `$BARRACUDA`
+points at the compiler (default `./barracuda`). Each case runs twice, clean
+and `--inject`, because a harness that can't fail isn't testing anything.
+
+Two kinds of test:
+
+- **cpu vs host** always runs. It checks the `--cpu` backend against a plain
+  host reference, which catches frontend, lowering and CPU codegen bugs.
+  Needs only `gcc`.
+- **cpu vs rv64** is the real cross-backend one: the same source through
+  `--cpu` and `--rv64`, diffed against each other and the host. Needs
+  `riscv64-unknown-elf-gcc` and `qemu-riscv64`; it skips cleanly without
+  them.
+
+## How it fits together
+
+`bc_diff.h` is the compare core: tolerance-based float diff with a report.
+It knows nothing about who produced the bytes, on purpose. Float is not
+exact across backends, so it is a tolerance check, not bit-for-bit, and you
+pick the tolerance to suit the kernel.
+
+Each backend has one job, produce its answer. `diff_vadd.c` runs the `--cpu`
+kernel in-process and `diff_vadd_rv.c` runs the `--rv64` kernel under qemu
+and writes the raw output bytes to stdout. `diff_xbackend.c` reads both and
+diffs everything against the host oracle. Adding a GPU runner later is the
+same shape: produce a buffer, hand it to `bc_diff_f32`. The compare logic
+never changes.
+
+## RISC-V gotchas (the ones that cost time)
+
+- **Run on Linux / WSL, not MinGW.** The CPU and rv64 backends emit System V
+  ELF objects with the SysV calling convention. MinGW gcc is Windows ABI, so
+  it will happily link the object and then segfault on the first call. Build
+  the host and run under a native Linux gcc.
+- **The rv64 host is freestanding.** `qemu-riscv64` user-mode does not give
+  newlib its syscalls and does not propagate the guest exit code, so the
+  runner skips libc: its own `_start`, raw `write`/`exit` ecalls, and the
+  verdict comes from the bytes it writes, never from `$?`.
+- **Set the global pointer.** A freestanding `_start` must set `gp` to
+  `__global_pointer$` first thing (`.option norelax` around the `la`). The
+  linker relaxes data loads to gp-relative, and without a valid `gp` they
+  land in the weeds. The symptom is a segfault that looks like nothing.
+- **Match the float ABI.** The rv64 objects declare hard float (lp64d), so
+  build the runner with `-march=rv64imfd -mabi=lp64d` or the link is a
+  mismatch.

--- a/tests/diff/bc_diff.h
+++ b/tests/diff/bc_diff.h
@@ -1,0 +1,94 @@
+/* bc_diff.h -- differential testing core for BarraCUDA backends.
+ *
+ * One IR, many targets. Run the same kernel through two of them, diff the
+ * output buffers, and you find out fast whether a wrong answer is your
+ * maths or the codegen. The CPU backend makes a fine oracle: it is the
+ * simplest target we have, stack-everything and no clever scheduling, so
+ * when CPU and GPU disagree the GPU is usually the one telling fibs.
+ *
+ * This header is just the compare half: tolerance, a tidy report, a
+ * verdict. It knows nothing about how either buffer was produced, which
+ * is the point. The CPU runner, an rv64-under-qemu runner, and a GPU
+ * runner (bc_dispatch) all feed the same comparison.
+ *
+ * Float is not exact across backends and that is fine. Transcendentals
+ * and approximate ops (rsqrt, sin, the usual suspects) drift a little
+ * between an x86 FPU and a GPU's fast-math unit, so this is a tolerance
+ * check, not a bit-for-bit one. Pick the tolerance to match the kernel.
+ */
+#ifndef BC_DIFF_H
+#define BC_DIFF_H
+
+#include <stddef.h>
+#include <math.h>
+#include <stdio.h>
+
+typedef struct {
+    size_t n;            /* elements compared                         */
+    size_t n_mismatch;   /* how many fell outside tolerance           */
+    size_t first_bad;    /* index of the first mismatch (n if none)   */
+    double max_abs_err;  /* largest |got - ref| seen                  */
+    double max_rel_err;  /* largest |got - ref| / |ref| seen          */
+    double got_at_first; /* the offending pair, for the report        */
+    double ref_at_first;
+} bc_diff_report_t;
+
+/* A single element passes if it is within EITHER the absolute or the
+ * relative tolerance. Two NaNs count as agreement (both backends gave
+ * up in the same place); a NaN facing a number does not. */
+static int bc_diff_ok_f32(float got, float ref, float abstol, float reltol)
+{
+    if (isnan(got) || isnan(ref)) return isnan(got) && isnan(ref);
+    double d = fabs((double)got - (double)ref);
+    if (d <= (double)abstol) return 1;
+    double r = fabs((double)ref);
+    return r > 0.0 && d <= (double)reltol * r;
+}
+
+/* Compare two float buffers. Returns the mismatch count (0 == clean) and
+ * fills rep if you hand it one. */
+static size_t bc_diff_f32(const float *got, const float *ref, size_t n,
+                          float abstol, float reltol,
+                          bc_diff_report_t *rep)
+{
+    bc_diff_report_t r;
+    r.n = n; r.n_mismatch = 0; r.first_bad = n;
+    r.max_abs_err = 0.0; r.max_rel_err = 0.0;
+    r.got_at_first = 0.0; r.ref_at_first = 0.0;
+
+    for (size_t i = 0; i < n; i++) {
+        double ad = fabs((double)got[i] - (double)ref[i]);
+        double rd = fabs((double)ref[i]) > 0.0
+                  ? ad / fabs((double)ref[i]) : 0.0;
+        if (ad > r.max_abs_err) r.max_abs_err = ad;
+        if (rd > r.max_rel_err) r.max_rel_err = rd;
+        if (!bc_diff_ok_f32(got[i], ref[i], abstol, reltol)) {
+            if (r.first_bad == n) {
+                r.first_bad = i;
+                r.got_at_first = (double)got[i];
+                r.ref_at_first = (double)ref[i];
+            }
+            r.n_mismatch++;
+        }
+    }
+    if (rep) *rep = r;
+    return r.n_mismatch;
+}
+
+/* Print a one-glance verdict. label names what was compared, e.g.
+ * "cpu vs host" or "cpu vs gpu". */
+static int bc_diff_print(const char *label, const bc_diff_report_t *r)
+{
+    if (r->n_mismatch == 0) {
+        printf("PASS  %-16s  %zu elems, max abs %.3g, max rel %.3g\n",
+               label, r->n, r->max_abs_err, r->max_rel_err);
+        return 0;
+    }
+    printf("FAIL  %-16s  %zu/%zu mismatched, first at [%zu] "
+           "got %.9g vs ref %.9g (max abs %.3g, max rel %.3g)\n",
+           label, r->n_mismatch, r->n, r->first_bad,
+           r->got_at_first, r->ref_at_first, r->max_abs_err, r->max_rel_err);
+    return 1;
+}
+
+#endif /* BC_DIFF_H */

--- a/tests/diff/diff_vadd.c
+++ b/tests/diff/diff_vadd.c
@@ -1,0 +1,53 @@
+/* diff_vadd.c -- worked differential test for the Triton vector_add kernel.
+ *
+ * Subject: the kernel as compiled by `barracuda --triton --cpu`, called
+ * the usual way (its own params, then the hidden nthreads). Oracle: the
+ * same sum worked out in plain host C. We diff the two.
+ *
+ * Right now the oracle is a host reference, which is enough to catch
+ * frontend, lowering and CPU-codegen bugs and runs on any machine. Swap
+ * the oracle for a second backend (rv64 under qemu, or a GPU run through
+ * bc_dispatch) and the comparison below does not change one line: that is
+ * the whole idea, the compare core does not care who produced the bytes.
+ *
+ * Build + run lives in run_diff.sh. Pass --inject to corrupt one output
+ * on purpose, which is how we check the harness fails when it should.
+ *
+ * Build (Linux / WSL):
+ *   ./barracuda --triton --cpu -o vadd.o tests/tri_vadd.py
+ *   gcc -no-pie -Itests/diff tests/diff/diff_vadd.c vadd.o -o diff_vadd -lm
+ *   ./diff_vadd            # PASS
+ *   ./diff_vadd --inject   # FAIL (proves the harness has teeth)
+ */
+#include <stdio.h>
+#include <string.h>
+#include "bc_diff.h"
+#include "vadd_io.h"
+
+/* x, y, out, n_elements, BLOCK_SIZE, then the hidden nthreads. */
+extern void vector_add(float *x, float *y, float *out,
+                       int n_elements, int block_size, int nthreads);
+
+int main(int argc, char **argv)
+{
+    int inject = (argc > 1 && strcmp(argv[1], "--inject") == 0);
+
+    float x[VADD_N], y[VADD_N], got[VADD_N], ref[VADD_N];
+    vadd_inputs(x, y);
+    for (int i = 0; i < VADD_N; i++) got[i] = -123.0f;
+
+    /* Subject: run the compiled kernel. One block, nthreads = N. */
+    vector_add(x, y, got, VADD_N, VADD_BLOCK, VADD_N);
+
+    /* Oracle: the answer we already know. */
+    for (int i = 0; i < VADD_N; i++) ref[i] = x[i] + y[i];
+
+    /* Simulate a backend that disagrees, to prove FAIL is reachable. */
+    if (inject) got[VADD_N / 3] += 1.0f;
+
+    bc_diff_report_t rep;
+    bc_diff_f32(got, ref, VADD_N, 1e-6f, 1e-5f, &rep);
+    int bad = bc_diff_print("cpu vs host", &rep);
+
+    return bad;
+}

--- a/tests/diff/diff_vadd_rv.c
+++ b/tests/diff/diff_vadd_rv.c
@@ -1,0 +1,64 @@
+/* diff_vadd_rv.c -- freestanding RV64 runner for the differential harness.
+ *
+ * qemu-riscv64 user-mode does not hand newlib its syscalls and does not
+ * propagate the guest exit code, so we skip libc entirely: our own
+ * _start, run the kernel, and write the raw output buffer to stdout. The
+ * x86 comparator reads those bytes and does the actual diffing, which is
+ * why this stays about thirty lines. One backend's only job here is to
+ * produce its answer; judging it happens somewhere with a printf.
+ *
+ * Build (Linux / WSL):
+ *   ./barracuda --triton --rv64 -o rv.o tests/tri_vadd.py
+ *   riscv64-unknown-elf-gcc -nostdlib -static -march=rv64imfd -mabi=lp64d \
+ *       -Itests/diff tests/diff/diff_vadd_rv.c rv.o -o rv_runner
+ *   qemu-riscv64 ./rv_runner > rvout.bin
+ */
+#include "vadd_io.h"
+
+/* x, y, out, n_elements, BLOCK_SIZE, then the hidden nthreads. */
+extern void vector_add(float *x, float *y, float *out,
+                       int n_elements, int block_size, int nthreads);
+
+/* BSS. The loader zero-fills it; we overwrite anyway. */
+static float x[VADD_N], y[VADD_N], out[VADD_N];
+
+/* Linux/riscv syscall numbers: write = 64, exit = 93. */
+static long sys_write(long fd, const void *buf, long n)
+{
+    register long a0 asm("a0") = fd;
+    register long a1 asm("a1") = (long)buf;
+    register long a2 asm("a2") = n;
+    register long a7 asm("a7") = 64;
+    asm volatile("ecall" : "+r"(a0) : "r"(a1), "r"(a2), "r"(a7) : "memory");
+    return a0;
+}
+
+static void sys_exit(long code)
+{
+    register long a0 asm("a0") = code;
+    register long a7 asm("a7") = 93;
+    asm volatile("ecall" : : "r"(a0), "r"(a7) : "memory");
+    __builtin_unreachable();
+}
+
+void _start(void)
+{
+    /* Set up the global pointer before touching any global. The linker
+     * relaxes data loads to gp-relative, and without a valid gp they land
+     * in the weeds, which is a segfault dressed up as a mystery. A real
+     * crt0 does exactly this; we have no crt0, so we do it ourselves. */
+    asm volatile(
+        ".option push\n"
+        ".option norelax\n"
+        "la gp, __global_pointer$\n"
+        ".option pop\n"
+        ::: "memory");
+
+    vadd_inputs(x, y);
+    for (int i = 0; i < VADD_N; i++) out[i] = -123.0f;
+
+    vector_add(x, y, out, VADD_N, VADD_BLOCK, VADD_N);
+
+    sys_write(1, out, (long)sizeof(out));
+    sys_exit(0);
+}

--- a/tests/diff/diff_xbackend.c
+++ b/tests/diff/diff_xbackend.c
@@ -1,0 +1,65 @@
+/* diff_xbackend.c -- the cross-backend comparator for vector_add.
+ *
+ * This is the real differential test: it runs the kernel on x86 (the
+ * --cpu backend, linked straight in), reads the rv64 backend's output
+ * from a file the qemu runner produced, and diffs both against the host
+ * oracle and against each other. Same BIR, two independent codegen paths.
+ * If cpu and rv64 disagree, one of them has a codegen bug and you find
+ * out without owning a GPU.
+ *
+ * The comparison lives here, on the libc side, because exit codes and
+ * printf actually work here. The rv64 side just hands us bytes.
+ *
+ * Build + run is wired into run_diff.sh. Pass --inject to corrupt the
+ * rv64 buffer on purpose, which proves the cpu-vs-rv64 diff has teeth.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "bc_diff.h"
+#include "vadd_io.h"
+
+extern void vector_add(float *x, float *y, float *out,
+                       int n_elements, int block_size, int nthreads);
+
+int main(int argc, char **argv)
+{
+    const char *rvpath = NULL;
+    int inject = 0;
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--inject") == 0) inject = 1;
+        else rvpath = argv[i];
+    }
+    if (!rvpath) {
+        fprintf(stderr, "usage: %s [--inject] <rv64-output.bin>\n", argv[0]);
+        return 2;
+    }
+
+    float x[VADD_N], y[VADD_N], cpu[VADD_N], rv[VADD_N], ref[VADD_N];
+    vadd_inputs(x, y);
+    for (int i = 0; i < VADD_N; i++) { cpu[i] = -123.0f; ref[i] = x[i] + y[i]; }
+
+    /* x86 backend, run in-process. */
+    vector_add(x, y, cpu, VADD_N, VADD_BLOCK, VADD_N);
+
+    /* rv64 backend, read the bytes qemu's runner wrote. */
+    FILE *f = fopen(rvpath, "rb");
+    if (!f) { perror("open rv64 output"); return 2; }
+    size_t got = fread(rv, sizeof(float), VADD_N, f);
+    fclose(f);
+    if (got != (size_t)VADD_N) {
+        fprintf(stderr, "short read: %zu/%d floats from %s\n",
+                got, VADD_N, rvpath);
+        return 2;
+    }
+
+    if (inject) rv[VADD_N / 3] += 1.0f;
+
+    bc_diff_report_t r;
+    int bad = 0;
+    bc_diff_f32(cpu, ref, VADD_N, 1e-6f, 1e-5f, &r); bad |= bc_diff_print("cpu vs host", &r);
+    bc_diff_f32(rv,  ref, VADD_N, 1e-6f, 1e-5f, &r); bad |= bc_diff_print("rv64 vs host", &r);
+    bc_diff_f32(cpu, rv,  VADD_N, 1e-6f, 1e-5f, &r); bad |= bc_diff_print("cpu vs rv64", &r);
+
+    return bad;
+}

--- a/tests/diff/run_diff.sh
+++ b/tests/diff/run_diff.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# run_diff.sh -- build and run the BarraCUDA differential tests.
+#
+# The idea: one BIR, many targets, so run the same kernel through two of
+# them and diff. If they disagree, one backend's codegen is lying, and the
+# CPU backend (simplest target) makes a good oracle. Runs on Linux or WSL,
+# because the CPU/rv64 backends emit System V ELF objects that link and run
+# with a native gcc, not under MinGW.
+#
+# Two flavours of test:
+#   * cpu vs host    -- always runs. Catches frontend/lowering/cpu-codegen
+#                       bugs against a plain host reference. Needs gcc only.
+#   * cpu vs rv64    -- genuine cross-backend. Same source through --cpu and
+#                       --rv64, diffed. Needs riscv64-unknown-elf-gcc and
+#                       qemu-riscv64; skipped cleanly if they are missing.
+#
+# Every case runs twice, clean (must PASS) and --inject (must FAIL), so a
+# green result actually means something. The compiler is found via
+# $BARRACUDA (default ./barracuda); point it at a Linux-built one.
+set -u
+
+BARRACUDA="${BARRACUDA:-./barracuda}"
+DIFFDIR="tests/diff"
+CC="${CC:-gcc}"
+RVCC="${RVCC:-riscv64-unknown-elf-gcc}"
+QEMU="${QEMU:-qemu-riscv64}"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+
+expect_pass() { if "$@" >/dev/null; then echo "  clean: PASS"; else echo "  clean: unexpected FAIL"; fail=1; fi; }
+expect_fail() { if "$@" >/dev/null; then echo "  inject: no FAIL, harness has no teeth"; fail=1; else echo "  inject: FAIL as expected"; fi; }
+
+# ---- cpu vs host: the portable smoke test ----
+cpu_vs_host() {
+    local src="$1" driver="$2" obj="$WORK/h.o" bin="$WORK/h"
+    echo "== cpu vs host: $src =="
+    "$BARRACUDA" --triton --cpu -o "$obj" "$src" 2>/dev/null \
+        && "$CC" -no-pie -O2 -I"$DIFFDIR" "$DIFFDIR/$driver" "$obj" -o "$bin" -lm 2>/dev/null \
+        || { echo "  build failed"; fail=1; return; }
+    "$bin"; expect_pass "$bin"; expect_fail "$bin" --inject
+}
+
+# ---- cpu vs rv64: the real cross-backend test ----
+cpu_vs_rv64() {
+    local src="$1" rvrunner="$2" cmp="$3"
+    echo "== cpu vs rv64: $src =="
+    if ! command -v "$RVCC" >/dev/null || ! command -v "$QEMU" >/dev/null; then
+        echo "  SKIP (need $RVCC and $QEMU)"; return
+    fi
+    local cpuobj="$WORK/x.o" rvobj="$WORK/r.o" runner="$WORK/rvrun" out="$WORK/rv.bin" bin="$WORK/xb"
+    "$BARRACUDA" --triton --cpu  -o "$cpuobj" "$src" 2>/dev/null \
+        && "$BARRACUDA" --triton --rv64 -o "$rvobj" "$src" 2>/dev/null \
+        && "$RVCC" -nostdlib -static -march=rv64imfd -mabi=lp64d -I"$DIFFDIR" "$DIFFDIR/$rvrunner" "$rvobj" -o "$runner" 2>/dev/null \
+        && "$QEMU" "$runner" > "$out" \
+        && "$CC" -no-pie -O2 -I"$DIFFDIR" "$DIFFDIR/$cmp" "$cpuobj" -o "$bin" -lm 2>/dev/null \
+        || { echo "  build/run failed"; fail=1; return; }
+    "$bin" "$out"; expect_pass "$bin" "$out"; expect_fail "$bin" --inject "$out"
+}
+
+cpu_vs_host "tests/tri_vadd.py" "diff_vadd.c"
+cpu_vs_rv64 "tests/tri_vadd.py" "diff_vadd_rv.c" "diff_xbackend.c"
+
+if [ "$fail" = "0" ]; then echo "all differential tests OK"; else echo "differential tests had failures"; fi
+exit "$fail"

--- a/tests/diff/vadd_io.h
+++ b/tests/diff/vadd_io.h
@@ -1,0 +1,24 @@
+/* vadd_io.h -- shared problem setup for the vector_add differential test.
+ *
+ * Every backend has to run the exact same numbers or the diff is
+ * meaningless, so the input generation lives here, once. It is pure float
+ * arithmetic with no libc, which means the freestanding rv64 runner can
+ * include it just as happily as the x86 host comparator. The values pick
+ * up signs and fractions on purpose, clean integers would let a broken
+ * float path slip through looking fine. */
+#ifndef VADD_IO_H
+#define VADD_IO_H
+
+#define VADD_N      64
+#define VADD_BLOCK  256
+
+static void vadd_inputs(float *x, float *y)
+{
+    const int mid = VADD_N / 2;
+    for (int i = 0; i < VADD_N; i++) {
+        x[i] = (float)(i - mid) * 0.5f;
+        y[i] = (float)(VADD_N - i) * -0.25f;
+    }
+}
+
+#endif /* VADD_IO_H */


### PR DESCRIPTION
0.5 release. The headline is that you can write a Triton kernel, matmul and all, and run it on a CPU with no GPU. See CHANGELOG.txt for the full stanza.

What's in:
- Cross-backend differential testing harness, cpu vs rv64, see tests/diff
- BC_VERSION + `--version` flag + CHANGELOG 0.5 stanza
- `examples/cpu_launch_matmul.c`, the headline demo, end-to-end verified
- Triton `tl.constexpr` params with defaults fold to literals and drop out of the runtime ABI
- main.c: `--cpu` / `--rv64` on their own now run sema (the lowerer needs it) and don't trip the parse-dump fallback by accident
- parser.c: `ast_dump` routes anon-buffer offsets through `P->anon_buf`, so typedef-struct kernels compile through `--cpu` and `--parse` no longer segfaults on the synthetic anon name

Tests: 277/278 pass, no regressions. Headline demo runs end-to-end.
