### PR TITLE
Bump version to 5.01

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,27 @@
 Booth — Changelog
 =================
 
+2026-07-14 — Version 5.01. So long, and thanks for all the fish.
+BarraCUDA was a good pun and a bad description, so it swam off: the
+compiler is Booth now, the binary is `kath`, and the version jumps
+to mark the line. First release under the new name; the rename note
+below has the why.
+
+Since 0.5 the compiler grew a spine on the CPU side. x86-64 and RV64
+both gained most of their scalar arithmetic, so a CUDA, HIP or Triton
+kernel now compiles and runs on a machine with no GPU in it at all.
+Tensix learned to emit native machine code for the baby RISC-V cores
+instead of leaning on a C++ handoff. `__device__` calls are inlined
+away before isel, so device helpers with control flow finally work on
+the GPU and vector backends. Diagnostics were rebuilt to read like
+Clang's, carets and colour and all, and the frontend picked up a pile
+of coverage.
+
+Thanks to the people who sent patches this cycle: @GauthamMK-0 for
+`__hip_bfloat16` and the `warpSize` builtin, @nataliakokoromyti for
+lowering `tl.where` to select and keeping the PTX header ASCII, and
+@kstppd for fixing the Makefile on non-x86 machines. Much appreciated.
+
 2026-06-29 — Renamed from BarraCUDA to Booth. The fish pun said
 "CUDA" while the whole point of the project is not needing CUDA, so
 it had to go. Booth honours Kathleen Booth: she wrote the first

--- a/src/barracuda.h
+++ b/src/barracuda.h
@@ -6,10 +6,10 @@
 #include <string.h>
 
 /* ---- Version ---- */
-#define BC_VERSION_MAJOR    0
-#define BC_VERSION_MINOR    5
+#define BC_VERSION_MAJOR    5
+#define BC_VERSION_MINOR    1
 #define BC_VERSION_PATCH    0
-#define BC_VERSION_STRING   "0.5.0"
+#define BC_VERSION_STRING   "5.01"
 
 /* The universe has limits. So do our buffers. No malloc, no madness. */
 #define BC_MAX_SOURCE       (4 * 1024 * 1024)


### PR DESCRIPTION
Tags the first release under the Booth name. `--version` now reports `Booth 5.01`, and the changelog gets a 5.01 entry covering the cycle since 0.5: CPU/RV64 scalar arithmetic, Tensix machine-code emit, `__device__` call inlining, Clang-style diagnostics, frontend coverage, and the rename itself.

Credits to @GauthamMK-0, @nataliakokoromyti and @kstppd for the patches this cycle (noted in the changelog).