### PR TITLE
amd: seed atomic RMW as divergent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ Booth — Changelog
 
 ### Backends
 
+- seed atomic RMW as divergent in the AMD divergence analysis, so a GEP off
+  an `atomicAdd` result no longer takes the scalar path and emits
+  `s_add_u32` with a VGPR source; unblocks per-thread SYSPRINT on AMD
+  (Zane Hambly, 2026-08-01)
+
 - #138: real high-half multiply on x86-64 and RV64, and an honest refusal
   where it cannot be done
   (Zane Hambly, 2026-07-26)

--- a/docs/mainframe.md
+++ b/docs/mainframe.md
@@ -36,7 +36,7 @@ bc_sp_register_sink("DEMO.RESULT", my_sink, NULL);
 bc_sp_drain(&buf);                                 /* sinks fire */
 ```
 
-See `examples/sysprint_kernel.cu` + `examples/launch_sysprint.c` for a full end-to-end demo. Works on the NVIDIA PTX and Tensix backends; the AMD path currently trips a regalloc bug on the byte-copy loop ([open issue](https://github.com/Zaneham/Booth/issues)), which gets its own follow-up.
+See `examples/sysprint_kernel.cu` + `examples/launch_sysprint.c` for a full end-to-end demo. Works on the AMD, NVIDIA PTX and Tensix backends.
 
 ## TDF (Tile DataFlow)
 

--- a/examples/launch_sysprint.c
+++ b/examples/launch_sysprint.c
@@ -9,11 +9,6 @@
  *             -o sp_demo.hsaco examples/sysprint_kernel.cu
  *         ./launch_sysprint sp_demo.hsaco
  *
- * Currently the AMD codegen for the payload-copy loop is hitting
- * a regalloc bug (s_add_u32: VGPR in scalar source). The NVIDIA
- * PTX and Tensix Metalium backends compile the kernel cleanly;
- * AMD coverage will catch up once the codegen issue is fixed.
- *
  * The launcher itself is the canonical pattern: allocate the
  * SYSPRINT buffer in host-coherent memory, hand its pointer to
  * the kernel as part of the kernarg block, dispatch, drain on

--- a/examples/sysprint_kernel.cu
+++ b/examples/sysprint_kernel.cu
@@ -3,13 +3,8 @@
  * Each thread computes c[i] = a[i] + b[i]. Thread 0 additionally
  * emits a single SYSPRINT record reporting the value it
  * produced; the host drains that record after the kernel
- * completes.
- *
- * The single-thread emit avoids the concurrent atomicAdd path
- * the per-thread variant would exercise; the per-thread version
- * is fine semantically but currently exposes an AMD backend
- * regalloc bug. The single-thread demo is enough to verify the
- * end-to-end wiring. */
+ * completes. Single-thread emit keeps the demo small; the
+ * per-thread concurrent-atomicAdd path is also supported. */
 
 #include "sysprint_device.h"
 #include "sysprint_classes.h"

--- a/src/amdgpu/isel.c
+++ b/src/amdgpu/isel.c
@@ -241,6 +241,11 @@ static void divergence_analysis(const bir_func_t *F)
             case BIR_SHFL_DOWN: case BIR_SHFL_XOR:
             case BIR_ALLOCA: /* per-thread scratch — inherently divergent */
             case BIR_MFMA:  /* matrix result is a collective warp operation */
+            /* atomic RMW: lanes serialise, each sees a different old value. oh yeah fixin it now: ZH */
+            case BIR_ATOMIC_ADD: case BIR_ATOMIC_SUB:
+            case BIR_ATOMIC_AND: case BIR_ATOMIC_OR: case BIR_ATOMIC_XOR:
+            case BIR_ATOMIC_MIN: case BIR_ATOMIC_MAX:
+            case BIR_ATOMIC_XCHG: case BIR_ATOMIC_CAS:
                 mark_divergent(idx);
                 break;
             case BIR_PARAM:


### PR DESCRIPTION
The AMD divergence analysis wasn't seeding `BIR_ATOMIC_*` RMW ops as divergent, so a GEP off an `atomicAdd` result took the scalar path in `isel_gep` and emitted `s_add_u32` with a VGPR source. The verifier caught it; hardware would just fault. This is the "AMD path currently trips a regalloc bug on the byte-copy loop" note in `docs/mainframe.md` and `examples/launch_sysprint.c`, both cleared here.

Seeds `BIR_ATOMIC_{ADD,SUB,AND,OR,XOR,MIN,MAX,XCHG,CAS}` alongside `BIR_THREAD_ID` and the shuffles. `ATOMIC_LOAD` and `ATOMIC_STORE` don't need seeding. Per-thread SYSPRINT now compiles clean on AMD; test suite unchanged (347/11/1 before and after).

Not GPU-executed on my end (no HSA runtime on this Windows box). Verifier's `vfy_sop` is check #1 for exactly this class, so it's a strong proxy, but the actual hardware run is worth doing before merging.