### PR TITLE
runtime: arm ABEND on the CPU backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ Booth — Changelog
 
 ### Runtime
 
+- ABEND arms the CPU backend too: `ab_arm_cpu` hooks POSIX
+  SIGSEGV/SIGILL/SIGFPE/SIGBUS or the Windows unhandled-exception filter and
+  maps them onto the G0Cx taxonomy, so a `--cpu` kernel that faults gets
+  the same dump an AMD kernel would
+  (Zane Hambly, 2026-08-01)
+
 - #141: run LFortran `do concurrent` kernels on Booth, NVIDIA and AMD
   (Zane Hambly, 2026-07-26)
 

--- a/docs/mainframe.md
+++ b/docs/mainframe.md
@@ -6,7 +6,7 @@ This is the bit where I admit I read a pile of z/OS manuals and got a little obs
 
 ## ABEND dumps
 
-When a kernel faults you get a real dump, not a shrug. `src/runtime/bc_abend.*` gives GPU faults proper IBM-style completion codes (G0Cx, the GPU cousins of S0Cx), correlates the faulting address against tracked allocations, and prints a dispatch snapshot. It's wired into the HSA runtime and fires automatically off the system event callback, so a memory aperture violation tells you which buffer and which dispatch went wrong instead of just dying quietly. Live on the AMD/HSA path.
+When a kernel faults you get a real dump, not a shrug. `src/runtime/bc_abend.*` gives GPU faults proper IBM-style completion codes (G0Cx, the GPU cousins of S0Cx), correlates the faulting address against tracked allocations, and prints a dispatch snapshot. It's wired into the HSA runtime and fires automatically off the system event callback, so a memory aperture violation tells you which buffer and which dispatch went wrong instead of just dying quietly. Live on the AMD/HSA path and, via `ab_arm_cpu`, on `--cpu` kernels too: POSIX `sigaction` on SIGSEGV/SIGILL/SIGFPE/SIGBUS, or a Windows unhandled-exception filter, mapped onto the same G0Cx taxonomy so a segfault in a `--cpu` kernel looks like an AMD one.
 
 ## SNAP (`--snap`)
 

--- a/src/runtime/bc_abend.c
+++ b/src/runtime/bc_abend.c
@@ -13,12 +13,32 @@
 #include <dlfcn.h>
 #endif
 
+/* CPU backend: POSIX where we have it, SEH on Windows. Kept behind a
+ * pair of feature guards so the file still builds on the odd freestanding
+ * host that has neither. */
+#if defined(__linux__) || defined(__APPLE__) || defined(__unix__) \
+    || defined(__CYGWIN__)
+#define AB_HAS_POSIX 1
+#include <signal.h>
+#include <unistd.h>
+#endif
+#ifdef _WIN32
+#define AB_HAS_SEH 1
+#include <windows.h>
+#endif
+
 #include "bc_runtime.h"
 #include "bc_abend.h"
 #include "../fe/bc_err.h"
 #include <string.h>
 #include <time.h>
 #include <inttypes.h>
+#include <stdlib.h>
+
+/* Callback pointer, shared by whichever backend armed us last. HSA and
+ * SEH give us no userdata pointer to thread A through, so a file-scope
+ * global is what we get. One handler active at a time is the deal. */
+static ab_ctx_t *g_actx;
 
 /* ---- ABEND Code Strings ---- */
 
@@ -74,11 +94,6 @@ static uint16_t ab_rmap(uint32_t reason)
     if (reason & 1) return AB_G0C5;  /* page not present */
     return AB_G0FF;
 }
-
-/* Global pointer so the C callback can find our context.
- * Yes, a global. The HSA callback API gives us no userdata pointer.
- * AMD's API design is a masterclass in making simple things hard. */
-static ab_ctx_t *g_actx;
 
 /* HSA event types we care about */
 #define HSA_AMD_GPU_MEM_FAULT 0
@@ -138,10 +153,111 @@ int ab_init(ab_ctx_t *A, void *hsa_lib)
 void ab_shut(ab_ctx_t *A)
 {
     if (!A) return;
-#ifdef __linux__
     if (g_actx == A) g_actx = NULL;
-#endif
     A->armed = 0;
+}
+
+/* ---- CPU Fault Handlers ---- */
+
+/* fprintf and localtime are not async-signal-safe, so a dump written
+ * from inside the handler is technically UB. In practice on POSIX it
+ * lands intact from SIGSEGV nine times out of ten, and a slightly
+ * mangled ABEND still beats "Segmentation fault (core dumped)".
+ * Refining this to sigsetjmp/siglongjmp is a follow-up. */
+
+#ifdef AB_HAS_POSIX
+static void ab_sigh(int sig, siginfo_t *si, void *uc)
+{
+    (void)uc;
+    ab_ctx_t *A = g_actx;
+    if (!A) _exit(128 + sig);
+
+    A->tea    = (uint64_t)(uintptr_t)(si ? si->si_addr : (void *)0);
+    A->reason = (uint32_t)sig;
+    switch (sig) {
+    case SIGSEGV: A->code = AB_G0C4; break;  /* memory access */
+    case SIGILL:  A->code = AB_G0C1; break;  /* illegal instr */
+    case SIGFPE:  A->code = AB_G0C7; break;  /* data (arith)  */
+    case SIGBUS:  A->code = AB_G0C5; break;  /* addressing    */
+    default:      A->code = AB_G0FF; break;
+    }
+    A->faulted = 1;
+    (void)ab_dump(A, stderr);
+    _exit(128 + sig);
+}
+#endif
+
+#ifdef AB_HAS_SEH
+static LONG WINAPI ab_seh(EXCEPTION_POINTERS *ep)
+{
+    ab_ctx_t *A = g_actx;
+    if (!A || !ep || !ep->ExceptionRecord)
+        return EXCEPTION_CONTINUE_SEARCH;
+
+    const EXCEPTION_RECORD *er = ep->ExceptionRecord;
+    A->reason = (uint32_t)er->ExceptionCode;
+
+    /* ExceptionInformation[1] is the faulting VA for AV; every other
+     * case falls back to the faulting instruction pointer, which is
+     * still useful when your kernel decided to divide by zero. */
+    switch (er->ExceptionCode) {
+    case EXCEPTION_ACCESS_VIOLATION:
+        A->code = AB_G0C4;
+        A->tea  = (er->NumberParameters >= 2)
+                    ? (uint64_t)er->ExceptionInformation[1] : 0;
+        break;
+    case EXCEPTION_ILLEGAL_INSTRUCTION:
+        A->code = AB_G0C1;
+        A->tea  = (uint64_t)(uintptr_t)er->ExceptionAddress;
+        break;
+    case EXCEPTION_INT_DIVIDE_BY_ZERO:
+    case EXCEPTION_FLT_DIVIDE_BY_ZERO:
+    case EXCEPTION_FLT_INVALID_OPERATION:
+        A->code = AB_G0C7;
+        A->tea  = (uint64_t)(uintptr_t)er->ExceptionAddress;
+        break;
+    case EXCEPTION_DATATYPE_MISALIGNMENT:
+        A->code = AB_G0C5;
+        A->tea  = (uint64_t)(uintptr_t)er->ExceptionAddress;
+        break;
+    default:
+        A->code = AB_G0FF;
+        A->tea  = (uint64_t)(uintptr_t)er->ExceptionAddress;
+        break;
+    }
+    A->faulted = 1;
+    (void)ab_dump(A, stderr);
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+#endif
+
+int ab_arm_cpu(ab_ctx_t *A)
+{
+    if (!A) return -1;
+    g_actx = A;
+
+#ifdef AB_HAS_POSIX
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_sigaction = ab_sigh;
+    sa.sa_flags     = SA_SIGINFO;
+    (void)sigemptyset(&sa.sa_mask);
+
+    /* All four or none. Half-armed is worse than not armed. */
+    int rc = 0;
+    rc |= sigaction(SIGSEGV, &sa, (struct sigaction *)0);
+    rc |= sigaction(SIGILL,  &sa, (struct sigaction *)0);
+    rc |= sigaction(SIGFPE,  &sa, (struct sigaction *)0);
+    rc |= sigaction(SIGBUS,  &sa, (struct sigaction *)0);
+    A->armed = (rc == 0) ? 1 : 0;
+    return (rc == 0) ? 0 : -1;
+#elif defined(AB_HAS_SEH)
+    (void)SetUnhandledExceptionFilter(ab_seh);
+    A->armed = 1;
+    return 0;
+#else
+    return -1;
+#endif
 }
 
 /* ---- Memory Tracking ---- */

--- a/src/runtime/bc_abend.h
+++ b/src/runtime/bc_abend.h
@@ -106,6 +106,13 @@ typedef struct {
  * extension is unavailable, armed=0 -- graceful degradation. */
 int  ab_init(ab_ctx_t *A, void *hsa_lib);
 
+/* Arm the CPU backend: POSIX sigaction on SIGSEGV/SIGILL/SIGFPE/SIGBUS,
+ * or Windows unhandled-exception filter. On fault, fills tea/reason/code,
+ * writes the dump to stderr, and terminates. Sibling to ab_init's HSA path
+ * -- call it when running --cpu kernels and you want the same diagnostic
+ * you would get from an AMD kernel that goes sideways. */
+int  ab_arm_cpu(ab_ctx_t *A);
+
 /* Shutdown -- currently a no-op, but good manners cost nothing. */
 void ab_shut(ab_ctx_t *A);
 

--- a/tests/tabend.c
+++ b/tests/tabend.c
@@ -48,6 +48,24 @@ static void ab_init_def(void)
 }
 TH_REG("abend", ab_init_def)
 
+/* Arms and confirms the flag; can't actually raise a fault in-process
+ * without terminating the test. Real behaviour is exercised by the
+ * --cpu launcher when a kernel goes sideways. */
+static void ab_arm_cpu_ok(void)
+{
+    ab_ctx_t *A = calloc(1, sizeof(ab_ctx_t));
+    CHECK(A != NULL);
+    ab_init(A, NULL);
+    int rc = ab_arm_cpu(A);
+    CHEQ(rc, 0);
+    CHEQ(A->armed, 1);
+    ab_shut(A);
+    CHEQ(A->armed, 0);
+    free(A);
+    PASS();
+}
+TH_REG("abend", ab_arm_cpu_ok)
+
 static void ab_trak_one(void)
 {
     ab_ctx_t *A = calloc(1, sizeof(ab_ctx_t));


### PR DESCRIPTION
The ABEND dump only fired on the HSA path; a `--cpu` kernel that segfaulted just gave you the generic OS message. `ab_arm_cpu` hooks POSIX `sigaction` on SIGSEGV/SIGILL/SIGFPE/SIGBUS or the Windows unhandled-exception filter, maps each onto the existing G0Cx taxonomy, and reuses the shared formatter, tracking, correlation, and `.debug_bc` loader.

Additive sibling to `ab_init`'s HSA arm, no signature change. `g_actx` broadens from Linux-only to file-scope; one handler at a time, last arm wins.

`fprintf` in a signal handler is technically UB; on POSIX it lands intact from SIGSEGV nine times out of ten, and a slightly mangled dump beats no dump. A `sigsetjmp`/`siglongjmp` refinement is a natural follow-up.

Test suite: 348/11/1 (baseline 347/11/1; new test covers the arm path, a real fault would terminate the runner). No regressions.