### PR TITLE
runtime: render the captured kernarg block as a SNAP section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@ Booth — Changelog
 
 ### Runtime
 
+- ABEND dump renders the captured kernarg block as a mainframe-style SNAP
+  section (offset gutter, four 4-byte hex groups, ASCII on the right), so
+  the arg bytes the launcher handed off are visible on every backend that
+  calls `ab_snag`, not just AMD
+  (Zane Hambly, 2026-08-02)
+
 - ABEND arms the CPU backend too: `ab_arm_cpu` hooks POSIX
   SIGSEGV/SIGILL/SIGFPE/SIGBUS or the Windows unhandled-exception filter and
   maps them onto the G0Cx taxonomy, so a `--cpu` kernel that faults gets

--- a/docs/mainframe.md
+++ b/docs/mainframe.md
@@ -10,7 +10,7 @@ When a kernel faults you get a real dump, not a shrug. `src/runtime/bc_abend.*` 
 
 ## SNAP (`--snap`)
 
-A parameter dump, basically. The mainframe crowd had this in the 70s and I kept wishing for it while debugging. With `--snap` the AMD backend writes each kernel parameter's register value into a host-visible buffer on entry, so when things go sideways you can read the evidence instead of staring at disassembly like it owes you money. AMD only for now.
+A parameter dump, basically. The mainframe crowd had this in the 70s and I kept wishing for it while debugging. With `--snap` the AMD backend writes each kernel parameter's register value into a host-visible buffer on entry, so when things go sideways you can read the evidence instead of staring at disassembly like it owes you money. The AMD compiler-side instrumentation is AMD-only; on every backend the ABEND dump also renders the launcher-side kernarg block (captured by `ab_snag`) as a hex+ASCII SNAP section, so `--cpu`, NVIDIA, and Tensix all get "here are the argument bytes the kernel actually saw" for free.
 
 ## SYSPRINT
 

--- a/src/runtime/bc_abend.c
+++ b/src/runtime/bc_abend.c
@@ -402,6 +402,28 @@ static void ab_line(FILE *out)
     fprintf(out, " ============================================================\n");
 }
 
+/* SNAP-style hex+ASCII dump. 16 bytes per line, +XXXX offset gutter,
+ * four 4-byte groups, ASCII on the right with non-print as '.'. Same
+ * shape as an IBM SNAP or z/OS storage dump. */
+static void ab_hex(FILE *out, const uint8_t *bytes, uint32_t n)
+{
+    uint32_t i, j;
+    for (i = 0; i < n; i += 16) {
+        fprintf(out, "   +%04X  ", i);
+        for (j = 0; j < 16; j++) {
+            if (i + j < n) fprintf(out, "%02X", bytes[i + j]);
+            else           fprintf(out, "  ");
+            if ((j & 3) == 3 && j < 15) fputc(' ', out);
+        }
+        fputs("  ", out);
+        for (j = 0; j < 16 && i + j < n; j++) {
+            uint8_t b = bytes[i + j];
+            fputc((b >= 0x20 && b < 0x7F) ? (int)b : '.', out);
+        }
+        fputc('\n', out);
+    }
+}
+
 int ab_dump(const ab_ctx_t *A, FILE *out)
 {
     if (!A || !out) return -1;
@@ -482,6 +504,19 @@ int ab_dump(const ab_ctx_t *A, FILE *out)
                 D->block[0], D->block[1], D->block[2]);
         if (D->args_sz > 0)
             fprintf(out, "   Args  %u bytes\n", D->args_sz);
+        fprintf(out, "\n");
+    }
+
+    /* ---- SNAP (kernarg / arg-block bytes) ----
+     * What MVS had in 1972 and CUDA still doesn't: the actual argument
+     * bytes the launcher handed off, so a wrong-sized pointer or a
+     * struct-padding surprise is visible instead of theoretical. */
+    if (D->args_sz > 0) {
+        uint32_t n = D->args_sz;
+        if (n > sizeof(A->args_snap)) n = (uint32_t)sizeof(A->args_snap);
+        fprintf(out, " SNAP (arg block, %u byte%s):\n",
+                n, (n == 1) ? "" : "s");
+        ab_hex(out, A->args_snap, n);
         fprintf(out, "\n");
     }
 

--- a/tests/tabend.c
+++ b/tests/tabend.c
@@ -327,6 +327,37 @@ static void ab_dump_disp(void)
 }
 TH_REG("abend", ab_dump_disp)
 
+static void ab_dump_snap(void)
+{
+    ab_ctx_t *A = calloc(1, sizeof(ab_ctx_t));
+    CHECK(A != NULL);
+    ab_init(A, NULL);
+    A->code = AB_G0C4;
+
+    /* Distinctive bytes so we can see them in the hex + ASCII gutter. */
+    bc_kernel_t k;
+    memset(&k, 0, sizeof(k));
+    k.kernarg_size = 24;
+    uint8_t args[24] = {
+        0xDE, 0xAD, 0xBE, 0xEF, 0x12, 0x34, 0x56, 0x78,
+        'H','e','l','l','o',' ','k','a', 't','h','!',0,0,0,0,0
+    };
+    ab_snag(A, &k, "snap_demo", "cpu",
+            1, 1, 1, 1, 1, 1, args, 24);
+
+    int n = ab_snap(A, obuf, (int)sizeof(obuf));
+    CHECK(n > 0);
+    CHECK(strstr(obuf, "SNAP") != NULL);
+    CHECK(strstr(obuf, "+0000") != NULL);          /* offset gutter */
+    CHECK(strstr(obuf, "DEADBEEF") != NULL);       /* hex */
+    CHECK(strstr(obuf, "Hello kath!") != NULL);    /* ASCII gutter */
+
+    ab_shut(A);
+    free(A);
+    PASS();
+}
+TH_REG("abend", ab_dump_snap)
+
 static void ab_dump_smap(void)
 {
     ab_ctx_t *A = calloc(1, sizeof(ab_ctx_t));

--- a/tests/tabend.c
+++ b/tests/tabend.c
@@ -349,8 +349,12 @@ static void ab_dump_snap(void)
     CHECK(n > 0);
     CHECK(strstr(obuf, "SNAP") != NULL);
     CHECK(strstr(obuf, "+0000") != NULL);          /* offset gutter */
-    CHECK(strstr(obuf, "DEADBEEF") != NULL);       /* hex */
-    CHECK(strstr(obuf, "Hello kath!") != NULL);    /* ASCII gutter */
+    CHECK(strstr(obuf, "+0010") != NULL);          /* second row */
+    CHECK(strstr(obuf, "DEADBEEF") != NULL);       /* hex row 0 */
+    CHECK(strstr(obuf, "74682100") != NULL);       /* hex row 1 */
+    /* ASCII gutter splits at 16B, so "Hello kath!" is never contiguous. */
+    CHECK(strstr(obuf, "Hello ka") != NULL);
+    CHECK(strstr(obuf, "th!") != NULL);
 
     ab_shut(A);
     free(A);


### PR DESCRIPTION
`ab_snag` already snapshotted the launcher's kernarg block into `A->args_snap` on every backend, but `ab_dump` only printed the size. This renders those bytes in the classic mainframe SNAP shape: `+XXXX` offset gutter, four 4-byte hex groups, ASCII on the right with non-print as `.`.

Independent of the AMD compiler-side `--snap` instrumentation, which stays where it is. This is the launcher-side story that works on `--cpu`, NVIDIA, and Tensix for free because they all call `ab_snag` before dispatch. When the AMD post-dispatch SNAP buffer eventually gets read back, the same `ab_hex` helper renders it.

Example output on a fake 24-byte arg block:
```
 SNAP (arg block, 24 bytes):
   +0000  DEADBEEF 12345678 48656C6C 6F206B61  .....4VxHello ka
   +0010  74682100 00000000                    th!.....
```

New `ab_dump_snap` test joins the existing 9 dump tests that use the `tmpfile()` helper, same shape and same pass-on-CI story.