### PR TITLE
A cast is only a cast if it names a type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ Booth — Changelog
 
 ### Frontend
 
+- `(a) + (b)` adds again; the parser treated any parenthesised identifier as a
+  type name without asking whether it named one, so the left operand vanished
+  into a cast with no diagnostic (Zane Hambly, 2026-09-03)
+
+- the cast test is now the type name registry, so the registry has to be
+  complete. Template type parameters, `using X = T` aliases and the type names
+  sema resolves without a typedef (`size_t`, `uint32_t`, `float4` and the rest)
+  all reach it. A compound literal through a typedef, `(pair){1, 2}`, parses
+  for the first time, and `sizeof(name)` where the name is a type reads as a
+  type rather than an expression (Zane Hambly, 2026-09-03)
+
 - `kath --mlir` reads MLIR text, no LLVM in the path. Čertík's pure-C
   reader vendored under `src/mlir/vendor` (mlir 826b69c9, corec a160199d),
   reached only through `src/mlir/mlir_fe.c` (Zane Hambly, 2026-08-11)

--- a/src/fe/parser.c
+++ b/src/fe/parser.c
@@ -197,12 +197,41 @@ static const char *tntxt(const parser_t *P, uint32_t off)
                                : P->src + off;
 }
 
+/* Names sema resolves as types with no typedef anywhere in the source: the
+ * stdint spellings, the half formats, and the CUDA vector types. The parser
+ * has to recognise them too, or (uint32_t)-1 reads as a subtraction. Keep in
+ * step with resolve_typespec in sema.c. */
+static const char *const btnams[] = {
+    "size_t", "ptrdiff_t",
+    "int8_t", "uint8_t", "int16_t", "uint16_t",
+    "int32_t", "uint32_t", "int64_t", "uint64_t",
+    "half", "__half", "_Float16",
+    "nv_bfloat16", "__nv_bfloat16", "__bfloat16", "__hip_bfloat16",
+    "float2", "float3", "float4",
+    "double2", "double3", "double4",
+    "int2", "int3", "int4",
+    "uint2", "uint3", "uint4",
+    "char2", "char3", "char4",
+    "uchar2", "uchar3", "uchar4",
+    "short2", "short3", "short4",
+    "ushort2", "ushort3", "ushort4",
+    "long2", "long3", "long4",
+    "ulong2", "ulong3", "ulong4",
+    "longlong2", "ulonglong2",
+    "dim3"
+};
+
 static int is_reg_type(const parser_t *P, uint32_t off, uint16_t len)
 {
     const char *q = tntxt(P, off);
     for (int i = 0; i < P->num_tnames; i++) {
         if (P->tnames[i].len == len &&
             memcmp(tntxt(P, P->tnames[i].off), q, len) == 0)
+            return 1;
+    }
+    for (size_t i = 0; i < sizeof btnams / sizeof btnams[0]; i++) {
+        if (strlen(btnams[i]) == (size_t)len &&
+            memcmp(btnams[i], q, len) == 0)
             return 1;
     }
     return 0;
@@ -415,25 +444,22 @@ static int looks_like_cast(parser_t *P)
     if (t == TOK_IDENT) {
         const token_t *id = &P->tokens[P->pos + 1 < P->num_tokens
                                         ? P->pos + 1 : P->num_tokens - 1];
-        int known = is_reg_type(P, id->offset, (uint16_t)id->len);
-        if (peek_type(P, 2) == TOK_RPAREN) {
-            int after = peek_type(P, 3);
-            /* (ident) *expr — the classic C ambiguity. Could be
-             * cast+deref OR multiplication. Only treat as cast if
-             * we KNOW it's a type. Cost of getting this wrong: one
-             * GPU aperture fault and an afternoon of disassembly. */
-            if (after == TOK_STAR || after == TOK_AMP) {
-                if (known) return 1;
-            } else if (can_start_unary(after)) {
-                /* (ident)0, (ident)x etc. — no mul/deref ambiguity,
-                 * safe to assume cast (covers template params too) */
-                return 1;
-            }
-        }
         /* (ident*) or (ident**) — pointer cast to struct/vector type.
-         * Star is INSIDE the parens (part of the type), not ambiguous. */
+         * Star is INSIDE the parens (part of the type), not ambiguous, and
+         * a mismatch backtracks below, so a header typedef still casts. */
         if (peek_type(P, 2) == TOK_STAR)
             return 1;
+        /* (ident) anything — the classic C ambiguity. Every prefix operator
+         * that is also infix reaches here, so the only sound test is whether
+         * the name is a type in scope. Guess it and (a) + (b) quietly becomes
+         * b. Cost of getting this wrong: one GPU aperture fault and an
+         * afternoon of disassembly. */
+        if (peek_type(P, 2) == TOK_RPAREN &&
+            is_reg_type(P, id->offset, (uint16_t)id->len)) {
+            int after = peek_type(P, 3);
+            if (can_start_unary(after) || after == TOK_LBRACE)
+                return 1;
+        }
     }
     return 0;
 }
@@ -524,7 +550,10 @@ static uint32_t parse_primary(parser_t *P)
         uint32_t n = alloc_node(P, AST_SIZEOF);
         advance(P);
         if (match(P, TOK_LPAREN)) {
-            if (is_type_keyword(cur_type(P))) {
+            if (is_type_keyword(cur_type(P)) ||
+                (cur_type(P) == TOK_IDENT &&
+                 peek_type(P, 1) == TOK_RPAREN &&
+                 is_reg_type(P, cur(P)->offset, (uint16_t)cur(P)->len))) {
                 uint16_t sq = 0, sc = 0;
                 uint32_t inner = parse_type_spec(P, &sq, &sc);
                 while (cur_type(P) == TOK_STAR) advance(P);
@@ -1026,6 +1055,11 @@ static uint32_t parse_declaration(parser_t *P)
                 P->nodes[name].d.text.len = cur(P)->len;
                 advance(P);
                 add_child(P, tp, name);
+                /* A type parameter is a type name for the body below it,
+                 * so (T)x still casts once the registry is the test. */
+                if (P->nodes[tp].d.oper.flags == 0)
+                    reg_tname(P, P->nodes[name].d.text.offset,
+                              (uint16_t)P->nodes[name].d.text.len);
             }
             if (cur_type(P) == TOK_ASSIGN) {
                 advance(P);
@@ -1081,6 +1115,10 @@ static uint32_t parse_declaration(parser_t *P)
             add_child(P, u, name);
             match(P, TOK_DCOLON);
             if (cur_type(P) == TOK_ASSIGN) {
+                /* using X = T is a typedef wearing a nicer jacket, so X has
+                 * to reach the registry the same way. */
+                reg_tname(P, P->nodes[name].d.text.offset,
+                          (uint16_t)P->nodes[name].d.text.len);
                 advance(P);
                 uint16_t q2, c2;
                 uint32_t alias_type = parse_type_spec(P, &q2, &c2);

--- a/tests/trpi.c
+++ b/tests/trpi.c
@@ -112,3 +112,115 @@ static void rpi03(void)
     PASS();
 }
 TH_REG("rpi", 3, "a constant above INT32_MAX is not clamped", rpi03)
+
+/* looks_like_cast read `( ident )` before any prefix operator as a cast to a
+ * type called ident, without ever asking whether ident named a type. Only `+`
+ * and `-` are also infix, so `(a) + (b)` became a cast applied to `+(b)` and
+ * the left operand vanished with no diagnostic. `-` left the tell, `sub 0, b`.
+ *
+ * The fixture stays on disk after a failure, so build/rpi04.cu names the case
+ * that broke. */
+static void rpi04(void)
+{
+    static const struct { const char *ex; const char *ir; } cs[] = {
+        { "(a) + (b)",        "add i32 %0, %1"     },
+        { "(a) - (b)",        "sub i32 %0, %1"     },
+        { "(a) + b",          "add i32 %0, %1"     },
+        { "(b) + (a)",        "add i32 %1, %0"     },
+        { "(a) + (a * 2)",    "add i32 %0, %2"     },
+        { "(a) + a * 2",      "add i32 %0, %2"     },
+        { "(a) + (a)",        "add i32 %0, %0"     },
+        { "((a)) + (b)",      "add i32 %0, %1"     },
+        { "(a) * (b)",        "mul i32 %0, %1"     },
+        { "(a) & (b)",        "and i32 %0, %1"     },
+        { "(a) / (b)",        "sdiv i32 %0, %1"    },
+        { "(a) < (b)",        "icmp slt i32 %0, %1"},
+        { "(a * 2) + (a)",    "add i32 %2, %0"     },
+        { "(a + 1) + (a * 2)","add i32 %2, %3"     },
+    };
+    char cmd[512];
+
+    for (size_t i = 0; i < sizeof cs / sizeof cs[0]; i++) {
+        FILE *f = fopen("build/rpi04.cu", "w");
+        CHNE(f, NULL);
+        fprintf(f, "__device__ int f(int a, int b){ return %s; }\n", cs[i].ex);
+        fclose(f);
+
+        snprintf(cmd, sizeof cmd, "%s --ir build/rpi04.cu", BC_BIN);
+        CHEQ(th_run(cmd, obuf, (int)sizeof obuf), 0);
+        CHNE(strstr(obuf, cs[i].ir), NULL);
+    }
+    PASS();
+}
+TH_REG("rpi", 4, "a parenthesised variable is not a cast", rpi04)
+
+/* The other half of the same test. Tightening it must not cost a real cast,
+ * so every shape a typedef name reaches the parser in is checked here, and
+ * `(pair){...}` is one the loose rule never recognised at all. */
+static void rpi05(void)
+{
+    static const struct { const char *src; const char *ir; } cs[] = {
+        { "typedef int myint;\n"
+          "__device__ int f(int a, int b){ return (myint)(a) + b; }\n",
+          "add i32 %0, %1" },
+
+        { "typedef int myint;\n"
+          "__device__ int f(int a, int b){ (void)a; return (myint) + b; }\n",
+          "ret i32 %1" },
+
+        { "typedef int myint;\n"
+          "__device__ int f(int a, int b){ (void)a; (void)b; return (myint)-1; }\n",
+          "ret i32 4294967295" },
+
+        { "typedef int myint;\n"
+          "__device__ int f(void *p){ return *(myint*)p; }\n",
+          "bitcast ptr<global, void> %0 to ptr<global, i32>" },
+
+        { "typedef struct { int x; int y; } pair;\n"
+          "__device__ int f(int a, int b){ pair p = (pair){ a, b }; return p.y; }\n",
+          "store i32 %1, %6" },
+
+        { "__device__ int f(int a, int b){ return (int)(uint32_t)-1 + a + b; }\n",
+          "add i32 4294967295, %0" },
+
+        { "using myint = int;\n"
+          "__device__ int f(int a, int b){ return (myint)(a) + b; }\n",
+          "add i32 %0, %1" },
+    };
+    char cmd[512];
+
+    for (size_t i = 0; i < sizeof cs / sizeof cs[0]; i++) {
+        FILE *f = fopen("build/rpi05.cu", "w");
+        CHNE(f, NULL);
+        fputs(cs[i].src, f);
+        fclose(f);
+
+        snprintf(cmd, sizeof cmd, "%s --ir build/rpi05.cu", BC_BIN);
+        CHEQ(th_run(cmd, obuf, (int)sizeof obuf), 0);
+        CHNE(strstr(obuf, cs[i].ir), NULL);
+    }
+    PASS();
+}
+TH_REG("rpi", 5, "a typedef name still casts", rpi05)
+
+/* A template type parameter is a type name for the body below it. It is not a
+ * typedef and never reached the registry, so it survived on the loose rule
+ * alone and (T)a + b would have started returning b. */
+static void rpi06(void)
+{
+    static const char *const src =
+        "template<typename T> __device__ T g(T a, T b){ return (T)a + b; }\n";
+    char cmd[512];
+
+    FILE *f = fopen("build/rpi06.cu", "w");
+    CHNE(f, NULL);
+    fputs(src, f);
+    fclose(f);
+
+    snprintf(cmd, sizeof cmd, "%s --parse build/rpi06.cu", BC_BIN);
+    CHEQ(th_run(cmd, obuf, (int)sizeof obuf), 0);
+    CHNE(strstr(obuf, "(binary +"), NULL);
+    CHNE(strstr(obuf, "(cast"), NULL);
+    PASS();
+}
+TH_REG("rpi", 6, "a template type parameter names a type", rpi06)


### PR DESCRIPTION
The parser treated any parenthesised identifier as a type name without asking whether it named one, so `(a) + (b)` compiled to `b`.